### PR TITLE
Auto merge Dependabot Pull-Requests when new patches are given

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,3 +84,28 @@ jobs:
         with:
           name: Application
           path: build/libs/kafka-merge-purge-${{ needs.metadata.outputs.version }}.jar
+
+  auto-merge:
+    runs-on: ubuntu-latest
+
+    needs: jar
+
+    if: ${{ github.actor == 'dependabot[bot]' }}
+
+    steps:
+      - name: Dependabot fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Add dependabot auto merge label
+        run: gh pr edit "$PR_URL" --add-label "dependabot-auto-merge"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot pull requests (patches)
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request is intended to simplify the dependency management.
In the first step, automatically merge Dependabot pull requests when new patches are given.

- Updated pull-request workflow
- Label auto merged PRs with **dependabot-auto-merge**
- Auto Merge Only Patches for now