### PR TITLE
Dependabot: Change update behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -90,28 +90,3 @@ jobs:
         with:
           name: Application
           path: build/libs/kafka-merge-purge-${{ needs.metadata.outputs.version }}.jar
-
-  auto-merge:
-    runs-on: ubuntu-latest
-
-    needs: jar
-
-    if: ${{ github.actor == 'dependabot[bot]' }}
-
-    steps:
-      - name: Dependabot fetch metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Add dependabot auto merge label
-        run: gh pr edit "$PR_URL" --add-label "dependabot-auto-merge"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Enable auto-merge for Dependabot pull requests (patches)
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Dependabot currently considers major updates in our automated update mechanism. However, these updates usually require big code changes by hand. Dependabot is mainly used by us for bug fixes and security patches, therefore major releases will be ignored for the time being. 

- Dependabot: Switch to weekly-update interval
  -  Ignore major updates for any package
- Pull-Request Workflow: Remove auto-merge functionality because it's not safe to use

